### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,4 +1,6 @@
 name: Build Release Candidate
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/magicalyak/transmissionvpn/security/code-scanning/4](https://github.com/magicalyak/transmissionvpn/security/code-scanning/4)

To fix this problem, explicitly set the `permissions:` block at the top level of the workflow file (recommended), or for each job as needed. The safest default is `contents: read`, which limits GITHUB_TOKEN to only reading repository contents and prevents accidental or malicious modifications. If any job needs broader access (for example, uploading releases or creating pull requests), additional write permissions for those specific scopes should be added at the job level.  

**Steps:**  
- Add a `permissions:` block immediately under the workflow `name:` at the root of the file.  
- Set least privilege required for the workflow:
  - For most build/testing workflows, this is:  
    ```yaml
    permissions:
      contents: read
    ```
- If jobs such as artifact upload, release creation, or pull request modification are present and need write access, add a job-specific `permissions:` block only to those jobs.
- In this case, uploading artifacts (using `actions/upload-artifact@v4`) does NOT require additional permissions. There is no sign that this workflow creates releases or modifies metadata that would require write access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
