### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-tagging.yml
+++ b/.github/workflows/validate-tagging.yml
@@ -1,4 +1,6 @@
 name: Validate Docker Hub Tagging
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/magicalyak/transmissionvpn/security/code-scanning/1](https://github.com/magicalyak/transmissionvpn/security/code-scanning/1)

To fix this issue, you should add a `permissions:` block at the workflow level in `.github/workflows/validate-tagging.yml`, directly after the workflow `name:` and before the `on:` block. The permissions granted should be the minimum required for the workflow to function. Based on the provided workflow, it only reads code and runs Docker metadata simulations, so the minimal permission needed is `contents: read`. No write capability or access to other resources is required.

**Detailed Steps:**

- Edit `.github/workflows/validate-tagging.yml`.
- Insert a block:
  ```yaml
  permissions:
    contents: read
  ```
  Directly after `name: Validate Docker Hub Tagging` (i.e. before `on:`).

This will restrict the GITHUB_TOKEN permissions such that only read access to repository contents is allowed, following best practices.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
