### PR TITLE
Update base image to Transmission 4.0.6-r4-ls321

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Main image - Pin to specific version for better security tracking
-# Updated to latest stable release (4.0.6-r4-ls320 from 2025-11-25)
-FROM lscr.io/linuxserver/transmission:4.0.6-r4-ls320
+# Updated to latest stable release (4.0.6-r4-ls321 from 2025-12-02)
+FROM lscr.io/linuxserver/transmission:4.0.6-r4-ls321
 
 # TRANSMISSION_VERSION is inherited from the upstream linuxserver/transmission image
 ENV PUID=911


### PR DESCRIPTION
## Summary
- Updates base image from 4.0.6-r4-ls320 to 4.0.6-r4-ls321
- Released upstream on 2025-12-02

## Changes
Upstream release notes: https://github.com/linuxserver/docker-transmission/releases/tag/4.0.6-r4-ls321

## Test plan
- CI will build and test multi-architecture images
- Verify container starts correctly with VPN