### PR TITLE
Update base image to linuxserver/transmission:4.0.6-r5-ls322

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Main image - Pin to specific version for better security tracking
-# Updated to latest stable release (4.0.6-r4-ls321 from 2025-12-02)
-FROM lscr.io/linuxserver/transmission:4.0.6-r4-ls321
+# Updated to latest stable release (4.0.6-r5-ls322 from 2025-12-21)
+FROM lscr.io/linuxserver/transmission:4.0.6-r5-ls322
 
 # TRANSMISSION_VERSION is inherited from the upstream linuxserver/transmission image
 ENV PUID=911


### PR DESCRIPTION
## Summary
- Updates base image from 4.0.6-r4-ls321 to 4.0.6-r5-ls322
- Keeps up with latest linuxserver/transmission security patches and updates

## Changes
- Dockerfile: Updated FROM tag to 4.0.6-r5-ls322

## Testing
- Build and verify container starts correctly
- Verify Transmission and VPN functionality